### PR TITLE
feat: add main entrypoint and go-to-definition support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-grlx-lsp
+/grlx-lsp
 dist/
 target/

--- a/cmd/grlx-lsp/main.go
+++ b/cmd/grlx-lsp/main.go
@@ -1,0 +1,57 @@
+// Command grlx-lsp implements a Language Server Protocol server for grlx
+// recipe files (.grlx).
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.lsp.dev/jsonrpc2"
+
+	"github.com/gogrlx/grlx-lsp/internal/lsp"
+	"github.com/gogrlx/grlx-lsp/internal/schema"
+)
+
+// version is set at build time via ldflags.
+var version = "dev"
+
+func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "--version", "-v":
+			fmt.Println("grlx-lsp", version)
+			os.Exit(0)
+		case "--help", "-h":
+			fmt.Println("grlx-lsp — Language Server Protocol server for grlx recipe files")
+			fmt.Println()
+			fmt.Println("Usage: grlx-lsp [options]")
+			fmt.Println()
+			fmt.Println("The server communicates over stdin/stdout using JSON-RPC 2.0.")
+			fmt.Println("Configure your editor to launch this binary as an LSP server")
+			fmt.Println("for .grlx files.")
+			fmt.Println()
+			fmt.Println("Options:")
+			fmt.Println("  --version, -v  Print version and exit")
+			fmt.Println("  --help, -h     Print this help and exit")
+			os.Exit(0)
+		}
+	}
+
+	ctx := context.Background()
+	registry := schema.DefaultRegistry()
+	handler := lsp.NewHandler(registry)
+
+	stream := jsonrpc2.NewStream(stdrwc{})
+	conn := jsonrpc2.NewConn(stream)
+	handler.SetConn(conn)
+	conn.Go(ctx, handler.Handle)
+	<-conn.Done()
+}
+
+// stdrwc adapts stdin/stdout to an io.ReadWriteCloser.
+type stdrwc struct{}
+
+func (stdrwc) Read(p []byte) (int, error)  { return os.Stdin.Read(p) }
+func (stdrwc) Write(p []byte) (int, error) { return os.Stdout.Write(p) }
+func (stdrwc) Close() error                { return os.Stdin.Close() }

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -1,0 +1,89 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+)
+
+func (h *Handler) handleDefinition(_ context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	ctx := context.Background()
+
+	var params protocol.DefinitionParams
+	if err := json.Unmarshal(req.Params(), &params); err != nil {
+		return reply(ctx, nil, err)
+	}
+
+	doc := h.getDocument(string(params.TextDocument.URI))
+	if doc == nil || doc.recipe == nil {
+		return reply(ctx, nil, nil)
+	}
+
+	line := lineAt(doc.content, int(params.Position.Line))
+	col := int(params.Position.Character)
+
+	// Only provide definition inside requisite value positions
+	if !isInRequisiteValue(doc.content, int(params.Position.Line)) {
+		return reply(ctx, nil, nil)
+	}
+
+	// Extract the step ID reference under the cursor
+	ref := stepRefAtPosition(line, col)
+	if ref == "" {
+		return reply(ctx, nil, nil)
+	}
+
+	// Find the step definition
+	for _, s := range doc.recipe.Steps {
+		if s.ID == ref && s.IDNode != nil {
+			loc := protocol.Location{
+				URI: params.TextDocument.URI,
+				Range: protocol.Range{
+					Start: protocol.Position{
+						Line:      uint32(s.IDNode.Line - 1),
+						Character: uint32(s.IDNode.Column - 1),
+					},
+					End: protocol.Position{
+						Line:      uint32(s.IDNode.Line - 1),
+						Character: uint32(s.IDNode.Column - 1 + len(s.ID)),
+					},
+				},
+			}
+			return reply(ctx, loc, nil)
+		}
+	}
+
+	return reply(ctx, nil, nil)
+}
+
+// stepRefAtPosition extracts a step ID reference from a requisite value line.
+// Requisite values appear after "- <condition>: " as plain text.
+func stepRefAtPosition(line string, col int) string {
+	trimmed := strings.TrimSpace(line)
+
+	// Look for pattern "- <condition>: <step ref>"
+	for _, prefix := range []string{
+		"- require: ", "- require_any: ",
+		"- onchanges: ", "- onchanges_any: ",
+		"- onfail: ", "- onfail_any: ",
+	} {
+		if strings.HasPrefix(trimmed, prefix) {
+			// The rest of the trimmed line is the step ID
+			ref := strings.TrimSpace(trimmed[len(prefix):])
+			if ref == "" {
+				return ""
+			}
+			// Check the cursor is actually in the value portion
+			indent := len(line) - len(strings.TrimLeft(line, " \t"))
+			valueStart := indent + len(prefix)
+			if col >= valueStart {
+				return ref
+			}
+		}
+	}
+
+	return ""
+}

--- a/internal/lsp/definition_test.go
+++ b/internal/lsp/definition_test.go
@@ -1,0 +1,54 @@
+package lsp
+
+import (
+	"testing"
+)
+
+func TestStepRefAtPosition(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		col  int
+		want string
+	}{
+		{
+			name: "require ref",
+			line: "        - require: install nginx",
+			col:  25,
+			want: "install nginx",
+		},
+		{
+			name: "cursor before value",
+			line: "        - require: install nginx",
+			col:  10,
+			want: "",
+		},
+		{
+			name: "onchanges ref",
+			line: "        - onchanges: build app",
+			col:  25,
+			want: "build app",
+		},
+		{
+			name: "no match",
+			line: "      - name: foo",
+			col:  10,
+			want: "",
+		},
+		{
+			name: "empty value",
+			line: "        - require: ",
+			col:  19,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stepRefAtPosition(tt.line, tt.col)
+			if got != tt.want {
+				t.Errorf("stepRefAtPosition(%q, %d) = %q, want %q", tt.line, tt.col, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/lsp/handler.go
+++ b/internal/lsp/handler.go
@@ -63,6 +63,8 @@ func (h *Handler) Handle(ctx context.Context, reply jsonrpc2.Replier, req jsonrp
 		return h.handleCompletion(ctx, reply, req)
 	case "textDocument/hover":
 		return h.handleHover(ctx, reply, req)
+	case "textDocument/definition":
+		return h.handleDefinition(ctx, reply, req)
 	case "textDocument/diagnostic":
 		return reply(ctx, nil, nil)
 	default:
@@ -80,7 +82,8 @@ func (h *Handler) handleInitialize(_ context.Context, reply jsonrpc2.Replier, _ 
 			CompletionProvider: &protocol.CompletionOptions{
 				TriggerCharacters: []string{".", ":", "-", " "},
 			},
-			HoverProvider: true,
+			HoverProvider:      true,
+			DefinitionProvider: true,
 		},
 		ServerInfo: &protocol.ServerInfo{
 			Name:    "grlx-lsp",


### PR DESCRIPTION
## Changes

- **Add `cmd/grlx-lsp/main.go`** — the installable binary entry point. The README references `go install github.com/gogrlx/grlx-lsp/cmd/grlx-lsp@latest` but no main package existed until now.
  - Supports `--version`/`-v` and `--help`/`-h` flags
  - Reads/writes LSP JSON-RPC over stdin/stdout

- **Add `textDocument/definition`** — go-to-definition for step ID references inside requisite blocks (`require`, `onchanges`, `onfail`, etc.). Clicking a step reference jumps to its definition.

- **Fix `.gitignore`** — anchor `/grlx-lsp` so the `cmd/grlx-lsp/` directory isn't accidentally ignored.

## Testing

All existing tests pass. New tests added for `stepRefAtPosition` helper.