### PR TITLE
fix(recipe): reject steps with multiple method keys

### DIFF
--- a/internal/recipe/recipe.go
+++ b/internal/recipe/recipe.go
@@ -140,7 +140,7 @@ func (r *Recipe) parseStep(idNode, bodyNode *yaml.Node) {
 		return
 	}
 
-	if len(bodyNode.Content) < 2 {
+	if len(bodyNode.Content) != 2 {
 		r.Errors = append(r.Errors, ParseError{
 			Message: "step must have exactly one ingredient.method key",
 			Line:    bodyNode.Line,

--- a/internal/recipe/recipe_test.go
+++ b/internal/recipe/recipe_test.go
@@ -102,6 +102,31 @@ steps:
 	}
 }
 
+func TestParseStepWithMultipleMethodKeys(t *testing.T) {
+	data := []byte(`
+steps:
+  bad step:
+    file.exists:
+      - name: /tmp/a
+    file.absent:
+      - name: /tmp/b
+`)
+	r := Parse(data)
+
+	found := false
+	for _, e := range r.Errors {
+		if e.Message == "step must have exactly one ingredient.method key" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about multiple ingredient.method keys, got: %v", r.Errors)
+	}
+	if len(r.Steps) != 0 {
+		t.Fatalf("expected invalid step to be skipped, got %d parsed steps", len(r.Steps))
+	}
+}
+
 func TestStepIDs(t *testing.T) {
 	data := []byte(`
 steps:


### PR DESCRIPTION
## Summary
- reject step bodies unless they contain exactly one ingredient.method entry
- add regression coverage for multi-method step definitions

## Testing
- go test ./...
- staticcheck ./...