### PR TITLE
fix(lsp): diagnose duplicate step ids

### DIFF
--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -42,11 +42,24 @@ func (h *Handler) diagnose(doc *document) []protocol.Diagnostic {
 	}
 
 	stepIDs := make(map[string]bool)
+	duplicateStepIDs := make(map[string]bool)
 	for _, s := range doc.recipe.Steps {
+		if stepIDs[s.ID] {
+			duplicateStepIDs[s.ID] = true
+		}
 		stepIDs[s.ID] = true
 	}
 
 	for _, s := range doc.recipe.Steps {
+		if duplicateStepIDs[s.ID] {
+			diags = append(diags, protocol.Diagnostic{
+				Range:    yamlNodeRange(s.IDNode),
+				Severity: protocol.DiagnosticSeverityError,
+				Source:   "grlx-lsp",
+				Message:  "duplicate step ID: " + s.ID,
+			})
+		}
+
 		if s.Ingredient == "" {
 			continue
 		}

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -78,6 +78,33 @@ func TestDiagnoseRequisiteUnknownRef(t *testing.T) {
 	}
 }
 
+func TestDiagnoseDuplicateStepIDs(t *testing.T) {
+	h := NewHandler(schema.DefaultRegistry())
+	src := `steps:
+  duplicate:
+    file.exists:
+      - name: /tmp/a
+  duplicate:
+    file.exists:
+      - name: /tmp/b`
+	doc := &document{
+		content: src,
+		recipe:  recipe.Parse([]byte(src)),
+	}
+
+	diags := h.diagnose(doc)
+	duplicateCount := 0
+	for _, d := range diags {
+		if d.Severity == protocol.DiagnosticSeverityError && d.Message == "duplicate step ID: duplicate" {
+			duplicateCount++
+		}
+	}
+
+	if duplicateCount != 2 {
+		t.Fatalf("expected duplicate step ID diagnostic on both step definitions, got %d diagnostics: %v", duplicateCount, diags)
+	}
+}
+
 func TestIsValidRequisiteType(t *testing.T) {
 	validTypes := []string{"require", "require_any", "onchanges", "onchanges_any", "onfail", "onfail_any"}
 	for _, rt := range validTypes {


### PR DESCRIPTION
## Summary
- report duplicate step IDs as diagnostics on each conflicting step definition
- add regression coverage for duplicate step IDs

## Testing
- go test ./...
- staticcheck ./...