### PR TITLE
feat(lsp): add property hover documentation

### DIFF
--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -24,14 +24,23 @@ func (h *Handler) handleHover(_ context.Context, reply jsonrpc2.Replier, req jso
 		return reply(ctx, nil, nil)
 	}
 
-	line := lineAt(doc.content, int(params.Position.Line))
+	lineNumber := int(params.Position.Line)
+	line := lineAt(doc.content, lineNumber)
 	word := wordAtPosition(line, int(params.Position.Character))
 
 	if word == "" {
 		return reply(ctx, nil, nil)
 	}
 
-	// Check if it's an ingredient.method reference
+	if prop := h.findPropertyHover(doc, lineNumber, word); prop != nil {
+		return reply(ctx, &protocol.Hover{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: buildPropertyMarkdown(prop.Ingredient, prop.Method, prop.Property),
+			},
+		}, nil)
+	}
+
 	if strings.Contains(word, ".") {
 		parts := strings.SplitN(word, ".", 2)
 		if len(parts) == 2 {
@@ -48,7 +57,6 @@ func (h *Handler) handleHover(_ context.Context, reply jsonrpc2.Replier, req jso
 		}
 	}
 
-	// Check if it's just an ingredient name
 	ing := h.registry.FindIngredient(word)
 	if ing != nil {
 		var methods []string
@@ -63,7 +71,6 @@ func (h *Handler) handleHover(_ context.Context, reply jsonrpc2.Replier, req jso
 		}, nil)
 	}
 
-	// Check if it's a requisite type
 	for _, rt := range h.registry.RequisiteTypes {
 		if rt.Name == word {
 			return reply(ctx, &protocol.Hover{
@@ -76,6 +83,44 @@ func (h *Handler) handleHover(_ context.Context, reply jsonrpc2.Replier, req jso
 	}
 
 	return reply(ctx, nil, nil)
+}
+
+type propertyHoverMatch struct {
+	Ingredient string
+	Method     string
+	Property   schema.Property
+}
+
+func (h *Handler) findPropertyHover(doc *document, lineNumber int, word string) *propertyHoverMatch {
+	if doc.recipe == nil {
+		return nil
+	}
+
+	for _, step := range doc.recipe.Steps {
+		if step.MethodNode == nil || step.MethodNode.Line-1 > lineNumber {
+			continue
+		}
+		for _, prop := range step.Properties {
+			if prop.Key != word || prop.KeyNode == nil || prop.KeyNode.Line-1 != lineNumber {
+				continue
+			}
+			method := h.registry.FindMethod(step.Ingredient, step.Method)
+			if method == nil {
+				return nil
+			}
+			for _, schemaProp := range method.Properties {
+				if schemaProp.Key == prop.Key {
+					return &propertyHoverMatch{
+						Ingredient: step.Ingredient,
+						Method:     step.Method,
+						Property:   schemaProp,
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func buildMethodMarkdown(ingredient string, m *schema.Method) string {
@@ -98,6 +143,22 @@ func buildMethodMarkdown(ingredient string, m *schema.Method) string {
 			}
 			sb.WriteString("| `" + p.Key + "` | " + p.Type + " | " + req + " | " + desc + " |\n")
 		}
+	}
+	return sb.String()
+}
+
+func buildPropertyMarkdown(ingredient, method string, property schema.Property) string {
+	var sb strings.Builder
+	sb.WriteString("### `" + property.Key + "`\n\n")
+	sb.WriteString("Used by `" + ingredient + "." + method + "`\n\n")
+	sb.WriteString("- Type: `" + property.Type + "`\n")
+	if property.Required {
+		sb.WriteString("- Required: yes\n")
+	} else {
+		sb.WriteString("- Required: no\n")
+	}
+	if property.Description != "" {
+		sb.WriteString("\n" + property.Description)
 	}
 	return sb.String()
 }

--- a/internal/lsp/hover_test.go
+++ b/internal/lsp/hover_test.go
@@ -19,17 +19,12 @@ func TestBuildMethodMarkdown(t *testing.T) {
 
 	md := buildMethodMarkdown("file", m)
 
-	// Should contain header
 	if !contains(md, "### file.managed") {
 		t.Error("expected markdown header with ingredient.method")
 	}
-
-	// Should contain description
 	if !contains(md, "Download and manage a file") {
 		t.Error("expected description in markdown")
 	}
-
-	// Should contain properties table
 	if !contains(md, "| Property |") {
 		t.Error("expected properties table")
 	}
@@ -39,8 +34,6 @@ func TestBuildMethodMarkdown(t *testing.T) {
 	if !contains(md, "| `source` |") {
 		t.Error("expected source property in table")
 	}
-
-	// Required properties should show "yes"
 	if !contains(md, "| yes |") {
 		t.Error("expected 'yes' for required properties")
 	}
@@ -56,7 +49,6 @@ func TestBuildMethodMarkdownNoProperties(t *testing.T) {
 	if !contains(md, "### pkg.cleaned") {
 		t.Error("expected header")
 	}
-	// Should not contain a table
 	if contains(md, "| Property |") {
 		t.Error("should not have property table for method with no properties")
 	}
@@ -76,6 +68,70 @@ func TestBuildMethodMarkdownNoDescription(t *testing.T) {
 	}
 	if !contains(md, "| `name` |") {
 		t.Error("expected name property")
+	}
+}
+
+func TestBuildPropertyMarkdown(t *testing.T) {
+	md := buildPropertyMarkdown("file", "managed", schema.Property{
+		Key:         "source",
+		Type:        "string",
+		Required:    true,
+		Description: "Source URL",
+	})
+
+	if !contains(md, "### `source`") {
+		t.Error("expected property header")
+	}
+	if !contains(md, "Used by `file.managed`") {
+		t.Error("expected owning method")
+	}
+	if !contains(md, "- Type: `string`") {
+		t.Error("expected property type")
+	}
+	if !contains(md, "- Required: yes") {
+		t.Error("expected required marker")
+	}
+	if !contains(md, "Source URL") {
+		t.Error("expected property description")
+	}
+}
+
+func TestFindPropertyHover(t *testing.T) {
+	h := NewHandler(schema.DefaultRegistry())
+	src := `steps:
+  manage config:
+    file.managed:
+      - name: /etc/example.conf
+      - source: salt://example.conf
+`
+	h.updateDocument("file:///test.grlx", src)
+	doc := h.getDocument("file:///test.grlx")
+
+	match := h.findPropertyHover(doc, 4, "source")
+	if match == nil {
+		t.Fatal("expected property hover match")
+	}
+	if match.Ingredient != "file" || match.Method != "managed" {
+		t.Fatalf("unexpected match owner: %#v", match)
+	}
+	if match.Property.Key != "source" {
+		t.Fatalf("unexpected property match: %#v", match)
+	}
+}
+
+func TestFindPropertyHoverIgnoresUnknownLine(t *testing.T) {
+	h := NewHandler(schema.DefaultRegistry())
+	src := `steps:
+  manage config:
+    file.managed:
+      - name: /etc/example.conf
+`
+	h.updateDocument("file:///test.grlx", src)
+	doc := h.getDocument("file:///test.grlx")
+
+	match := h.findPropertyHover(doc, 1, "manage")
+	if match != nil {
+		t.Fatalf("expected no property hover match, got %#v", match)
 	}
 }
 
@@ -113,9 +169,9 @@ func TestWordAtPositionEdgeCases(t *testing.T) {
 		want string
 	}{
 		{"", 0, ""},
-		{"hello", 100, "hello"},                // col beyond line length
-		{"  file.managed:", 2, "file.managed"}, // col 2 is start of word
-		{"file.managed:", 12, "file.managed"},  // just before colon
+		{"hello", 100, "hello"},
+		{"  file.managed:", 2, "file.managed"},
+		{"file.managed:", 12, "file.managed"},
 		{"a", 0, "a"},
 		{"a", 1, "a"},
 	}


### PR DESCRIPTION
## Summary
- add hover support for step property keys using the active ingredient.method schema
- render property hover docs with type, required status, and description
- cover the new hover behavior with focused tests

## Testing
- go test ./...
- staticcheck ./...