### PR TITLE
fix(lsp): support sequence-style requisite references

### DIFF
--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -224,20 +224,76 @@ func isInRequisites(line string) bool {
 }
 
 func isInRequisiteValue(content string, line int) bool {
+	_, ok := requisiteValueAtPosition(content, line, len(lineAt(content, line)))
+	return ok
+}
+
+func requisiteValueAtPosition(content string, line, col int) (string, bool) {
 	lines := strings.Split(content, "\n")
-	// Look backwards for a requisite condition key
-	for i := line; i >= 0 && i >= line-5; i-- {
+	if line < 0 || line >= len(lines) {
+		return "", false
+	}
+
+	currentLine := lines[line]
+	currentTrimmed := strings.TrimSpace(currentLine)
+	currentIndent := indentation(currentLine)
+
+	for i := line; i >= 0 && i >= line-8; i-- {
 		trimmed := strings.TrimSpace(lines[i])
-		if strings.HasPrefix(trimmed, "- require:") ||
-			strings.HasPrefix(trimmed, "- require_any:") ||
-			strings.HasPrefix(trimmed, "- onchanges:") ||
-			strings.HasPrefix(trimmed, "- onchanges_any:") ||
-			strings.HasPrefix(trimmed, "- onfail:") ||
-			strings.HasPrefix(trimmed, "- onfail_any:") {
-			return true
+		prefix, ok := requisitePrefix(trimmed)
+		if !ok {
+			continue
+		}
+
+		conditionIndent := indentation(lines[i])
+		if i == line {
+			ref := strings.TrimSpace(trimmed[len(prefix):])
+			if ref == "" {
+				return "", false
+			}
+			valueStart := conditionIndent + len(prefix)
+			if col < valueStart {
+				return "", false
+			}
+			return ref, true
+		}
+
+		if currentTrimmed == "" || currentIndent <= conditionIndent || !strings.HasPrefix(currentTrimmed, "- ") {
+			return "", false
+		}
+
+		ref := strings.TrimSpace(strings.TrimPrefix(currentTrimmed, "- "))
+		if ref == "" {
+			return "", false
+		}
+		valueStart := currentIndent + 2
+		if col < valueStart {
+			return "", false
+		}
+		return ref, true
+	}
+
+	return "", false
+}
+
+func requisitePrefix(trimmed string) (string, bool) {
+	for _, prefix := range []string{
+		"- require: ", "- require_any: ",
+		"- onchanges: ", "- onchanges_any: ",
+		"- onfail: ", "- onfail_any: ",
+		"- require:", "- require_any:",
+		"- onchanges:", "- onchanges_any:",
+		"- onfail:", "- onfail_any:",
+	} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return prefix, true
 		}
 	}
-	return false
+	return "", false
+}
+
+func indentation(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " \t"))
 }
 
 func isPropertyPosition(line string) bool {

--- a/internal/lsp/completion_test.go
+++ b/internal/lsp/completion_test.go
@@ -209,6 +209,34 @@ func TestIsInRequisiteValue(t *testing.T) {
 	}
 }
 
+func TestRequisiteValueAtPosition(t *testing.T) {
+	content := `steps:
+  first:
+    file.exists:
+      - name: /tmp/a
+  second:
+    file.exists:
+      - name: /tmp/b
+      - requisites:
+        - require: first
+        - onchanges:
+          - first`
+
+	ref, ok := requisiteValueAtPosition(content, 8, 20)
+	if !ok || ref != "first" {
+		t.Fatalf("expected inline requisite ref, got %q, %v", ref, ok)
+	}
+
+	ref, ok = requisiteValueAtPosition(content, 10, 12)
+	if !ok || ref != "first" {
+		t.Fatalf("expected sequence requisite ref, got %q, %v", ref, ok)
+	}
+
+	if _, ok = requisiteValueAtPosition(content, 9, 10); ok {
+		t.Fatal("condition line without value should not count as requisite value")
+	}
+}
+
 func TestIsPropertyPosition(t *testing.T) {
 	tests := []struct {
 		line string

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -22,17 +22,11 @@ func (h *Handler) handleDefinition(_ context.Context, reply jsonrpc2.Replier, re
 		return reply(ctx, nil, nil)
 	}
 
-	line := lineAt(doc.content, int(params.Position.Line))
 	col := int(params.Position.Character)
 
-	// Only provide definition inside requisite value positions
-	if !isInRequisiteValue(doc.content, int(params.Position.Line)) {
-		return reply(ctx, nil, nil)
-	}
-
-	// Extract the step ID reference under the cursor
-	ref := stepRefAtPosition(line, col)
-	if ref == "" {
+	// Only provide definition inside requisite value positions.
+	ref, ok := requisiteValueAtPosition(doc.content, int(params.Position.Line), col)
+	if !ok || ref == "" {
 		return reply(ctx, nil, nil)
 	}
 

--- a/internal/lsp/definition_test.go
+++ b/internal/lsp/definition_test.go
@@ -52,3 +52,21 @@ func TestStepRefAtPosition(t *testing.T) {
 		})
 	}
 }
+
+func TestRequisiteValueAtPositionSequenceItem(t *testing.T) {
+	content := `steps:
+  first:
+    file.exists:
+      - name: /tmp/a
+  second:
+    file.exists:
+      - name: /tmp/b
+      - requisites:
+        - require:
+          - first`
+
+	got, ok := requisiteValueAtPosition(content, 9, 12)
+	if !ok || got != "first" {
+		t.Fatalf("requisiteValueAtPosition() = %q, %v, want %q, true", got, ok, "first")
+	}
+}


### PR DESCRIPTION
## Summary
- support go-to-definition and completion for YAML sequence-style requisite values
- share requisite value parsing between completion context detection and definition lookup
- add regression coverage for inline and sequence requisite references

## Testing
- go test ./...